### PR TITLE
Update to dotnet 3.1 and remove chmod workaround

### DIFF
--- a/docker/dotnet/builder.dockerfile
+++ b/docker/dotnet/builder.dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1

--- a/docker/dotnet/utils/dotnet-yamldotnet.sh
+++ b/docker/dotnet/utils/dotnet-yamldotnet.sh
@@ -11,10 +11,6 @@ build () {
         --output /build/bin         \
         --configuration Release     \
         --runtime linux-musl-x64
-
-  # change permission from 744 to 755 (otherwise we
-  # get "permission denied" in runtime container)
-  chmod 755 /build/bin/*$1
 }
 
 build event


### PR DESCRIPTION
It was fixed by https://github.com/dotnet/core-setup/pull/8510 and 3.1 release docker was pushed 21 hours ago. :)